### PR TITLE
Rename launch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Decodes the image at `image_path` as per the entered password
 
         $ git clone https://github.com/NITDgpOS/SecureSnaps.git
         $ cd SecureSnaps
-        $ chmod +x SecureSnaps
-        $ ln -s "$HOME"/<path>/SecureSnaps /usr/local/bin
-        $ SecureSnaps
+        $ chmod +x ssnaps
+        $ ln -s "$HOME"/<path>/ssnaps /usr/local/bin
+        $ ssnaps
 
 ## Contribution Guidelines
 Please check the Open issues for the ongoing development in SecureSnaps.

--- a/ssnaps
+++ b/ssnaps
@@ -2,7 +2,7 @@
 
 function _help(){
 	echo "
-	Usage: SecureSnaps [-e] [-d] <file-path>
+	Usage: ssnaps [-e] [-d] <file-path>
 
 	Switches:
 		-e : encodes the image at <file-path> as per entered password
@@ -12,7 +12,7 @@ function _help(){
 		<file-path> : absolute/relative path to the image file
 
 	Example:
-		SecureSnaps -e <file-path>
+		ssnaps -e <file-path>
 	"
 }
 


### PR DESCRIPTION
Issue Reference: #28 

Changes proposed:
* Renamed launch command from SecureSnaps to ssnaps.

mention: @Aniq55 
